### PR TITLE
Map::insert may cause pointer issues if key exists

### DIFF
--- a/cocos/base/CCMap.h
+++ b/cocos/base/CCMap.h
@@ -274,9 +274,9 @@ public:
     void insert(const K& key, V object)
     {
         CCASSERT(object != nullptr, "Object is nullptr!");
+        object->retain();
         erase(key);
         _data.insert(std::make_pair(key, object));
-        object->retain();
     }
     
     /** 


### PR DESCRIPTION
Should retain before erase in case (key,object) pair is the same. 

PR for Issue #13656
cocos2d::Map may cause Dangling Pointers when inserting Ref Object which already exist in the Map
https://github.com/cocos2d/cocos2d-x/issues/13656
